### PR TITLE
Test with mocha < 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "chai": "^2.3.0",
     "memo-is": "0.0.2",
-    "mocha": ">=1.17",
+    "mocha": ">=1.17 <3.0.0",
     "should": ">=3.1",
     "sinon": "latest",
     "sinon-chai": "^2.7.0"


### PR DESCRIPTION
mocha 3+ is incompatible with resolution method usage. Attempting to run
with mocha 3 encounters error:
```
Error: Resolution method is overspecified. Specify a callback *or*
return a Promise; not both.
```