### PR TITLE
Allow establishing TLS connection to RabbitMQ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 node_js:
-  - iojs
+  - 8
+  - 9
+  - 10
+addons:
+  apt:
+    packages:
+    - rabbitmq-server
 services:
   - rabbitmq
-before_script:
-  - npm install
-script: "./node_modules/.bin/mocha"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,24 @@ Inject the appropriate logger and set up connection parameters:
 ```coffee
 Freddy = require 'freddy'
 Freddy.addErrorListener(listener)
-Freddy.connect('amqp://guest:guest@localhost:5672', logger).done (freddy) ->
+Freddy.connect('amqp://guest:guest@localhost:5672', {logger}).done (freddy) ->
+  continueWith(freddy)
+, (error) ->
+  doSthWithError(error)
+```
+
+### TLS connection
+
+See http://www.squaremobius.net/amqp.node/ssl.html for available options.
+
+```coffee
+sslOptions = {
+  cert: fs.readFileSync('clientcert.pem'),
+  key: fs.readFileSync('clientkey.pem'),
+  ca: [fs.readFileSync('cacert.pem')]
+}
+
+Freddy.connect('amqps://localhost:5671', {logger, ...sslOptions}).done (freddy) ->
   continueWith(freddy)
 , (error) ->
   doSthWithError(error)

--- a/lib/freddy.coffee
+++ b/lib/freddy.coffee
@@ -1,13 +1,17 @@
 winston = require 'winston'
 FreddySetup = require './freddy/freddy_setup'
 
-defaultLogger = new winston.Logger
-  transports: [ new winston.transports.Console level: 'info', colorize: true, timestamp: true ]
+defaultLogger = winston.createLogger({
+  transports: [
+    new winston.transports.Console(level: 'info', colorize: true, timestamp: true)
+  ]
+})
 
 setup = null
-connect = (amqpUrl, logger = defaultLogger) ->
+
+connect = (amqpUrl, {logger = defaultLogger, ...amqpOptions}) ->
   setup = new FreddySetup(logger)
-  setup.connect(amqpUrl)
+  setup.connect(amqpUrl, amqpOptions)
 
 addErrorListener = (listener) ->
   setup.addErrorListener listener if setup

--- a/lib/freddy/freddy_setup.coffee
+++ b/lib/freddy/freddy_setup.coffee
@@ -13,8 +13,8 @@ class FreddySetup
   constructor: (@logger) ->
     @errorListeners = []
 
-  connect: (amqpUrl) ->
-    q(amqp.connect(amqpUrl)).then (@connection) =>
+  connect: (amqpUrl, amqpOptions) ->
+    q(amqp.connect(amqpUrl, amqpOptions)).then (@connection) =>
       @logger.info "Connection established to amqp"
 
       process.once 'SIGINT', @shutdown

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   },
   "main": "./lib/freddy",
   "dependencies": {
-    "coffee-script": ">=1.4",
     "amqplib": ">=0.4.2",
-    "winston": ">= 0.7",
     "async": ">=0.2.10",
+    "coffeescript": "^2.4.1",
+    "q": ">= 1.0",
     "underscore": ">=1.6",
-    "q": ">= 1.0"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freddy",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "author": "Urmas Talimaa <urmas7@gmail.com>",
   "description": "Simple messaging API supporting acknowledgements and request-response",
   "repository": {

--- a/test/consumer_test.coffee
+++ b/test/consumer_test.coffee
@@ -63,12 +63,12 @@ describe 'Consumer', ->
 
         it 'can cancel consuming', (done) ->
           TestHelper.deliver(@connection, @queue, @topicName, @msg)
-          q.delay(5)
+          q.delay(25)
           .then =>
             @responderHandler.cancel()
           .then =>
             TestHelper.deliver(@connection, @queue, @topicName, @msg)
-            q.delay(5)
+            q.delay(25)
           .done =>
             @receivedMessages.should.eql(1)
             done()

--- a/test/freddy_test.coffee
+++ b/test/freddy_test.coffee
@@ -9,14 +9,14 @@ describe 'Freddy', ->
   describe '.connect', ->
     context 'with correct amqp url', ->
       it 'can connect to amqp', (done) ->
-        Freddy.connect(TestHelper.amqpUrl, logger).done ->
+        Freddy.connect(TestHelper.amqpUrl, {logger}).done ->
           done()
         , =>
           done Error("Connection should have succeeded, but failed")
 
     context 'with incorrect amqp url', ->
       it 'cannot connect', (done) ->
-        Freddy.connect('amqp://wrong:wrong@localhost:9000', logger).done ->
+        Freddy.connect('amqp://wrong:wrong@localhost:9000', {logger}).done ->
           done(Error("Connection should have failed, but succeeded"))
         , =>
           done()
@@ -24,7 +24,7 @@ describe 'Freddy', ->
   context 'when connected', ->
     beforeEach (done) ->
       @randomDest = TestHelper.uniqueId()
-      Freddy.connect(TestHelper.amqpUrl, logger).done (@freddy) =>
+      Freddy.connect(TestHelper.amqpUrl, {logger}).done (@freddy) =>
         done()
       , (err) ->
         done(err)

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --require should
 --reporter spec
 --ui bdd
---compilers coffee:coffee-script/register
+--compilers coffee:coffeescript/register
 --recursive

--- a/test/test_helper.coffee
+++ b/test/test_helper.coffee
@@ -12,8 +12,9 @@ q         = require 'q'
 uniqueId = -> id = ""; id += Math.random().toString(36).substr(2) while id.length < 32; id.substr 0, 32
 
 logger = (level = 'debug') ->
-  new winston.Logger
+  winston.createLogger({
     transports: [ new winston.transports.Console level: level, colorize: true, timestamp: true ]
+  })
 
 deleteExchange = (connection, exchangeName) ->
   q(connection.createChannel()).then (channel) ->


### PR DESCRIPTION
Function `amqp.connect` can accepts second argument where we can specify
TLS-connection options.