### PR TITLE
Use amqp-connection-manager to maintain amqp connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freddy",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Urmas Talimaa <urmas7@gmail.com>",
   "description": "Simple messaging API supporting acknowledgements and request-response",
   "repository": {
@@ -13,6 +13,7 @@
   },
   "main": "./lib/freddy",
   "dependencies": {
+    "amqp-connection-manager": "^3.2.2",
     "amqplib": ">=0.4.2",
     "async": ">=0.2.10",
     "coffeescript": "^2.4.1",

--- a/test/consumer_test.coffee
+++ b/test/consumer_test.coffee
@@ -35,9 +35,11 @@ describe 'Consumer', ->
         @msg = test: 'data'
 
       afterEach (done) ->
-        @connection.createChannel().then (channel) =>
-          channel.deleteQueue(@queue)
-          done()
+        @connection.createChannel({
+          setup: (amqpChannel) =>
+            amqpChannel.deleteQueue(@queue)
+            done()
+        })
 
       it 'resolves when done', (done) ->
         @consumer.consume(@queue, (->)).then ->

--- a/test/freddy_test.coffee
+++ b/test/freddy_test.coffee
@@ -14,13 +14,6 @@ describe 'Freddy', ->
         , =>
           done Error("Connection should have succeeded, but failed")
 
-    context 'with incorrect amqp url', ->
-      it 'cannot connect', (done) ->
-        Freddy.connect('amqp://wrong:wrong@localhost:9000', {logger}).done ->
-          done(Error("Connection should have failed, but succeeded"))
-        , =>
-          done()
-
   context 'when connected', ->
     beforeEach (done) ->
       @randomDest = TestHelper.uniqueId()

--- a/test/test_helper.coffee
+++ b/test/test_helper.coffee
@@ -5,7 +5,7 @@ chai.use(sinonChai)
 global.expect = chai.expect
 
 winston   = require 'winston'
-amqp      = require 'amqplib'
+amqp      = require('amqp-connection-manager')
 amqpUrl   = "amqp://guest:guest@localhost:5672"
 q         = require 'q'
 
@@ -17,8 +17,13 @@ logger = (level = 'debug') ->
   })
 
 deleteExchange = (connection, exchangeName) ->
-  q(connection.createChannel()).then (channel) ->
-    channel.deleteExchange(exchangeName)
+  q(new Promise((resolve, reject) ->
+    connection.createChannel({
+      setup: (amqpChannel) ->
+        amqpChannel.deleteExchange(exchangeName)
+        resolve()
+    })
+  ))
 
 connect = ->
   q(amqp.connect(amqpUrl))


### PR DESCRIPTION
amqp-connection-manager allows maintaining a connection to at least one
broker by using a set of amqp URLs. The brokers are rotated in
round-robin.

This changes the public interface, as "error listeners" are no longer
called when connection to amqp drops.


Tested by linking against this version in kluster with:

Configuration change:
```yaml
   freddy:
-    url: "amqp://guest:guest@localhost:5672"
+    url:
+      - "amqp://guest:guest@localhost:5672"
+      - "amqp://uninvited:uninvited@localhost:5672"
```

, and executing `> rabbitmqctl close_all_connections rabbit@localhost`. The second connection was tried - which failed and then connection to the first URL was re-established.