### PR TITLE
Fix passing connection options to amqp.connect

### DIFF
--- a/lib/freddy/freddy_setup.coffee
+++ b/lib/freddy/freddy_setup.coffee
@@ -16,7 +16,7 @@ class FreddySetup
     @connectListeners = []
 
   connect: (amqpUrl, amqpOptions) ->
-    q(amqp.connect(amqpUrl, amqpOptions)).then (@connection) =>
+    q(amqp.connect(amqpUrl, {connectionOptions: amqpOptions})).then (@connection) =>
       @logger.info "Connection established to amqp"
 
       process.once 'SIGINT', @shutdown

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freddy",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Urmas Talimaa <urmas7@gmail.com>",
   "description": "Simple messaging API supporting acknowledgements and request-response",
   "repository": {


### PR DESCRIPTION
amqp-connection-manager takes it's own options and amqp connection
options must be passed under `connectionOptions` key.